### PR TITLE
added local docker build option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:alpine as build
+
+RUN apk update && apk upgrade && apk add --no-cache automake make gettext
+WORKDIR /app
+COPY . ./
+#     apk add --no-cache bash git openssh
+RUN make build
+
+CMD ["/app/run.sh"]
+

--- a/config.env.yml
+++ b/config.env.yml
@@ -1,0 +1,4 @@
+---
+client_id: "${CLIENT_ID}"
+client_secret: "${CLIENT_SECRET}"
+port: ${HTTP_PORT}

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,12 @@
+services:
+    adax-prometheus-exporter:
+        build: ./
+        ports:
+            - "8080:8080"
+        restart: unless-stopped
+        environment:
+            - HTTP_PORT=8080
+            # get this from your adax app, Account -> Account ID
+            - CLIENT_ID=123
+            # create/get this from 3rd party integrations -> Remote API
+            - CLIENT_SECRET=abc

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+envsubst </app/config.env.yml >/app/config.yml
+
+/app/adax-prometheus-exporter --config /app/config.yml


### PR DESCRIPTION
I run all my homebridge, prometheus and prometheus exporters as docker images, this addition brings a docker build process where you can just `git clone` the project, create a local docker-compose.yml file and import it in your existing docker-compose.yml file with
```yaml
services:
  external-exporters:
    extends:
      file: ./adax-prometheus-exporter/docker-compose.yml
      service: adax-prometheus-exporter
```